### PR TITLE
Bug/llm dynamic acting fixed

### DIFF
--- a/src/agentic_scraper/backend/api/routes/scrape.py
+++ b/src/agentic_scraper/backend/api/routes/scrape.py
@@ -94,7 +94,7 @@ async def _run_scrape_job(job_id: str, payload: ScrapeCreate, user: CurrentUser)
         # Execute pipeline
         urls = [str(u) for u in payload.urls]
         items, stats = await scrape_with_stats(urls, settings=merged_settings, openai=creds)
-        result_model: ScrapeResultFixed | ScrapeResultDynamic
+        result_model: ScrapeResultDynamic | ScrapeResultFixed
         # Persist final result
         if payload.agent_mode in {AgentMode.LLM_FIXED, AgentMode.RULE_BASED}:
             result_model = ScrapeResultFixed.from_internal(items, stats)

--- a/src/agentic_scraper/backend/api/schemas/scrape.py
+++ b/src/agentic_scraper/backend/api/schemas/scrape.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import datetime
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, model_validator
 
-from agentic_scraper.backend.api.schemas.items import ScrapedItemDTO
+from agentic_scraper.backend.api.schemas.items import (
+    ScrapedItemDynamicDTO,
+    ScrapedItemFixedDTO,
+)
 from agentic_scraper.backend.config.messages import MSG_ERROR_MISSING_FIELDS_FOR_AGENT
 from agentic_scraper.backend.config.types import (
     AgentMode,
@@ -14,7 +18,9 @@ from agentic_scraper.backend.config.types import (
     OpenAIModel,
 )
 
-# Reusable type for URL lists with validation and examples
+if TYPE_CHECKING:
+    from agentic_scraper.backend.scraper.schemas import ScrapedItem
+
 UrlsType = Annotated[
     list[HttpUrl],
     Field(
@@ -27,19 +33,10 @@ UrlsType = Annotated[
 
 class ScrapeCreate(BaseModel):
     """
-    Request payload to create a new scrape job.
+    Request payload for initiating a scrape job.
 
-    Args:
-        urls (list[HttpUrl]): URLs to scrape.
-        agent_mode (AgentMode): Extraction mode (e.g., adaptive, fixed, rule-based).
-        openai_model (OpenAIModel | None): Model used when an LLM agent is selected.
-        openai_credentials (OpenAIConfig | None): Optional per-request OpenAI credentials.
-        llm_concurrency (int | None): LLM parallelism; required for LLM agents.
-        llm_schema_retries (int | None): Schema retries for adaptive/fixed agents.
-        fetch_concurrency (int): Parallel fetch limit.
-        screenshot_enabled (bool): Capture screenshots during scraping.
-        verbose (bool): Increase logging/verbosity.
-        retry_attempts (int): Non-LLM retry attempts where applicable.
+    Validates that OpenAI-related fields are present when using an LLM-based
+    agent mode (non-rule-based).
     """
 
     urls: UrlsType
@@ -55,14 +52,6 @@ class ScrapeCreate(BaseModel):
 
     @model_validator(mode="after")
     def validate_openai_fields(self) -> ScrapeCreate:
-        """
-        Enforce OpenAI-related fields only when an LLM agent is selected.
-        Rule-based mode may omit all OpenAI fields.
-
-        Returns:
-            ScrapeCreate: The validated model.
-        """
-        # Works whether AgentMode is an Enum or Literal[str]
         mode_value = getattr(self.agent_mode, "value", self.agent_mode)
         if mode_value == AgentMode.RULE_BASED:
             return self
@@ -81,35 +70,70 @@ class ScrapeCreate(BaseModel):
                     agent_mode=mode_value, missing_fields=", ".join(missing)
                 )
             )
-
         return self
 
 
-class ScrapeResult(BaseModel):
-    """
-    Final job result payload returned when a job has succeeded.
+class ScrapeResultBase(BaseModel):
+    """Base model for scrape results returned in job responses."""
 
-    Args:
-        items (list[ScrapedItemDTO]): Extracted items across all URLs.
-        stats (dict[str, object]): Aggregated metrics (e.g., totals, duration).
+    stats: Mapping[str, object] = Field(
+        ..., description="Execution metrics (counts, duration, etc.)"
+    )
+
+
+class ScrapeResultFixed(ScrapeResultBase):
+    """
+    Scrape results for agents using a fixed schema.
+
+    Typically produced by `AgentMode.LLM_FIXED` or `AgentMode.RULE_BASED`.
     """
 
-    items: list[ScrapedItemDTO] = Field(..., description="Extracted items from all URLs.")
-    stats: dict[str, object] = Field(..., description="Execution metrics (counts, duration, etc.).")
+    items: list[ScrapedItemFixedDTO] = Field(..., description="Extracted items from all URLs.")
+
+    @classmethod
+    def from_internal(
+        cls,
+        items: list[ScrapedItem],
+        stats: Mapping[str, object],
+    ) -> ScrapeResultFixed:
+        """Convert internal scraper models to API DTOs."""
+        return cls(
+            items=[ScrapedItemFixedDTO.from_internal(i) for i in items],
+            stats=stats,
+        )
+
+
+class ScrapeResultDynamic(ScrapeResultBase):
+    """
+    Scrape results for agents using a dynamic schema.
+
+    Typically produced by `AgentMode.DYNAMIC_LLM`.
+    """
+
+    items: list[ScrapedItemDynamicDTO] = Field(
+        ..., description="Extracted items from all URLs, may include extra fields."
+    )
+
+    @classmethod
+    def from_internal(
+        cls,
+        items: list[ScrapedItem],
+        stats: Mapping[str, object],
+    ) -> ScrapeResultDynamic:
+        """Convert internal scraper models to API DTOs."""
+        return cls(
+            items=[ScrapedItemDynamicDTO.from_internal(i) for i in items],
+            stats=stats,
+        )
 
 
 class ScrapeJob(BaseModel):
     """
-    Representation of a scrape job resource for polling.
+    Represents a scrape job with its current state.
 
-    Args:
-        id (str): Unique job identifier.
-        status (JobStatus): Current state of the job.
-        created_at (datetime): Creation timestamp (UTC).
-        updated_at (datetime): Last update timestamp (UTC).
-        progress (float | None): 0..1 progress indicator while running.
-        error (str | None): Error message if the job failed.
-        result (ScrapeResult | None): Final result when status == 'succeeded'.
+    The `result` type depends on the agent mode used:
+    - Fixed schema → `ScrapeResultFixed`
+    - Dynamic schema → `ScrapeResultDynamic`
     """
 
     model_config = ConfigDict(extra="ignore")
@@ -122,11 +146,13 @@ class ScrapeJob(BaseModel):
         default=None, ge=0.0, le=1.0, description="0..1 progress while running."
     )
     error: str | None = Field(default=None, description="Populated when status == 'failed'.")
-    result: ScrapeResult | None = Field(
+    result: ScrapeResultFixed | ScrapeResultDynamic | None = Field(
         default=None, description="Present when status == 'succeeded'."
     )
 
 
 class ScrapeList(BaseModel):
+    """Paginated list of scrape jobs."""
+
     items: list[ScrapeJob]
     next_cursor: str | None = None

--- a/src/agentic_scraper/backend/api/schemas/scrape.py
+++ b/src/agentic_scraper/backend/api/schemas/scrape.py
@@ -146,7 +146,8 @@ class ScrapeJob(BaseModel):
         default=None, ge=0.0, le=1.0, description="0..1 progress while running."
     )
     error: str | None = Field(default=None, description="Populated when status == 'failed'.")
-    result: ScrapeResultFixed | ScrapeResultDynamic | None = Field(
+    # NOTE: Order matters. Pydantic tries union variants in order.
+    result: ScrapeResultDynamic | ScrapeResultFixed | None = Field(
         default=None, description="Present when status == 'succeeded'."
     )
 

--- a/src/agentic_scraper/backend/config/messages.py
+++ b/src/agentic_scraper/backend/config/messages.py
@@ -295,6 +295,12 @@ MSG_INFO_INLINE_KEY_MASKED_FALLBACK = (
     "[API] [ROUTE] [SCRAPE] Inline OpenAI key appears masked; falling back to stored credentials."
 )
 
+
+MSG_LOG_DEBUG_DYNAMIC_EXTRAS = (
+    "DEBUG dynamic extras check | agent_mode={agent_mode} | first_item_keys={keys}"
+)
+MSG_LOG_DYNAMIC_EXTRAS_ERROR = "Failed to inspect first item for dynamic extras: {error}"
+
 # ---------------------------------------------------------------------
 # core/
 # ---------------------------------------------------------------------

--- a/src/agentic_scraper/backend/scraper/schemas.py
+++ b/src/agentic_scraper/backend/scraper/schemas.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from agentic_scraper.backend.utils.validators import (
@@ -8,19 +10,11 @@ from agentic_scraper.backend.utils.validators import (
 
 class ScrapedItem(BaseModel):
     """
-    Represents structured data extracted from a single web page.
+    Internal representation of structured data extracted from a single web page.
 
-    This model is returned by all scraping agents. It includes common fields such as title,
-    description, price, and publication metadata. Extra fields from the LLM are allowed.
-
-    Fields:
-        url (HttpUrl): Source URL of the page.
-        title (str | None): Main title or heading.
-        description (str | None): Short description or summary.
-        price (float | None): Numeric price if detected.
-        author (str | None): Author or source of the content.
-        date_published (str | None): Publication date if known.
-        screenshot_path (str | None): Path to a captured screenshot image.
+    This model is returned by all scraping agents and includes common fields
+    such as title, description, price, and publication metadata.
+    Extra fields from the LLM are allowed.
     """
 
     url: HttpUrl
@@ -31,6 +25,7 @@ class ScrapedItem(BaseModel):
     date_published: str | None = Field(default=None, description="Publication date if known")
     screenshot_path: str | None = Field(default=None, description="Path to screenshot image")
 
+    # Cleaning / normalization validators
     _clean_title = field_validator("title", mode="before")(
         lambda v: validate_optional_str(v, "title")
     )
@@ -48,5 +43,5 @@ class ScrapedItem(BaseModel):
         lambda v: validate_optional_str(v, "screenshot_path")
     )
 
-    # Pydantic v2 configuration: allow extra fields returned by the LLM.
+    # Allow extra keys for dynamic agent outputs
     model_config = ConfigDict(extra="allow")

--- a/src/agentic_scraper/frontend/ui_runner.py
+++ b/src/agentic_scraper/frontend/ui_runner.py
@@ -71,7 +71,6 @@ from agentic_scraper.frontend.ui_runner_helpers import (
 )
 
 if TYPE_CHECKING:
-    from agentic_scraper.backend.scraper.schemas import ScrapedItem
     from agentic_scraper.frontend.models import PipelineConfig
 
 logger = logging.getLogger(__name__)
@@ -334,7 +333,9 @@ async def cancel_scrape_job(job_id: str) -> bool:
 # -------------------------
 # Public entry point used by the UI
 # -------------------------
-def run_scraper_pipeline(raw_input: str, config: PipelineConfig) -> tuple[list[ScrapedItem], int]:
+def run_scraper_pipeline(
+    raw_input: str, config: PipelineConfig
+) -> tuple[list[dict[str, Any]], int]:
     """
     Validate URLs, create a scrape job, poll until completion, and render results.
 


### PR DESCRIPTION
**PR Title:**
Preserve extra LLM fields in dynamic scrape results (API + frontend)

**Description:**
This PR ensures that extra fields returned by LLM-based dynamic agents are preserved end-to-end, from backend API responses to frontend display.

**Changes:**

**Backend (API)**

* Fixed bug where `llm_dynamic` agent results dropped LLM-added extra fields.
* Introduced `ScrapedItemDynamicDTO` with `extra="allow"` in API schemas.
* Added `.from_internal()` constructors to DTOs for consistent conversion from internal `ScrapedItem` models to API-facing schemas.
* Updated `ScrapeResultFixed` and `ScrapeResultDynamic` to use `.from_internal()` for cleaner separation between scraper internals and API models.

**Frontend**

* Updated `parse_job_result()` to correctly handle Pydantic object order for both fixed-schema (`ScrapedItemDTO`) and dynamic-schema (`ScrapedItemDynamicDTO`) results.
* Removed unnecessary re-validation of dynamic results, allowing extra fields from LLM agents to appear in the UI without loss.
* Standardized ordering and conversion logic for Pydantic v1/v2 objects.
* Added minor robustness improvements to prevent silent data loss when passing through dynamic fields.

**Impact:**

* Dynamic agent results now display all additional LLM-provided fields in the frontend.
* Backend API returns remain schema-compliant while supporting flexible dynamic extraction use cases.
